### PR TITLE
fix: handle nil BigQuery value for repeated message fields

### DIFF
--- a/encoding/protobq/load.go
+++ b/encoding/protobq/load.go
@@ -80,6 +80,9 @@ func (o UnmarshalOptions) loadListField(
 	if !bqFieldSchema.Repeated {
 		return fmt.Errorf("%s: unsupported field schema for list field: not repeated", field.Name())
 	}
+	if bqField == nil {
+		return nil
+	}
 	bqList, ok := bqField.([]bigquery.Value)
 	if !ok {
 		return fmt.Errorf("%s: unsupported BigQuery value for message: %v", field.Name(), bqField)


### PR DESCRIPTION
## Bug

`loadListField` crashes when BigQuery returns `nil` for an empty `repeated` message field:

```
unsupported BigQuery value for message: <nil>
```

### Reproduction

Any proto with a `repeated` message field that is empty when written to BigQuery:

```proto
message User {
  repeated UserModeration moderations = 24;
}

message UserModeration {
  ModerationAction action = 1;
  google.protobuf.Timestamp created_at = 2;
}
```

1. Marshal a `User` with empty `moderations` and write to BQ
2. Read the row back and unmarshal into a `User`
3. `loadListField` receives `nil` for the `moderations` field
4. The type assertion `bqField.([]bigquery.Value)` fails on `nil`

### Root Cause

`loadListField` does not handle `nil` values from BigQuery. When a `REPEATED RECORD` column has no entries, the BigQuery emulator (and potentially real BigQuery) returns `nil` rather than an empty `[]bigquery.Value{}`.

The singular field loader (`loadSingularField`) already handles this correctly at line 194:

```go
if bqField == nil {
    return protoreflect.ValueOf(nil), nil
}
```

But `loadListField` is missing this check.

Note: `repeated` scalar and enum fields are unaffected because they take the `unmarshalScalarListField` path which handles nil differently.

### Fix

Add a nil check at the top of `loadListField`, matching the pattern in `loadSingularField`. When `bqField` is `nil`, return `nil` (leaving the proto field as its default empty list).
